### PR TITLE
Docker-based MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.venv
+.vscode
+.dockerignore
+Dockerfile
+docker-compose.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  # Please re-enable this when the PR #2 has been merged
+  # pull_request:
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,33 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push images
+        run: |
+          docker compose build
+          docker compose push
+        env:
+          GIT_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          GIT_COMMIT: ${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,13 +6,12 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-# Install uv
 FROM python:3.12-slim
+
+ARG GIT_COMMIT
 
 LABEL org.opencontainers.image.source="https://github.com/Jij-Inc/Jij-MCP-Server"
 LABEL org.opencontainers.image.title="Jij MCP Server"
 LABEL org.opencontainers.image.description="A MCP server for supporting the implementation of JijModeling."
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.revision=$GIT_COMMIT
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Install uv
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.source="https://github.com/Jij-Inc/Jij-MCP-Server"
+LABEL org.opencontainers.image.title="Jij MCP Server"
+LABEL org.opencontainers.image.description="A MCP server for supporting the implementation of JijModeling."
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+ADD . /app
+WORKDIR /app
+RUN uv sync --frozen
+
+CMD ["uv", "run", "jij_mcp/server.py"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ This configuration specifies:
     - `run`: Command to execute the server
     - `jij_mcp/server.py`: Server script to run
 
+### Docker version
+
+[![Install with Docker in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=jij&inputs=%5B%5D&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22--platform%22%2C%22linux%2Famd64%22%2C%22ghcr.io%2Fjij-inc%2Fjij-mcp-server%3Alatest%22%5D%7D)
+
+```json
+{
+    "mcpServers": {
+        "jij": {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "--platform",
+                "linux/amd64",
+                "ghcr.io/jij-inc/jij-mcp-server:latest"
+            ],
+        }
+    }
+}
+```
+
 ## Available Tools
 
 ### JijModeling Tools

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/jij-inc/jij-mcp-server:latest
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+    image: ghcr.io/jij-inc/jij-mcp-server:${GIT_BRANCH:-latest}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  jij-mcp-server:
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ghcr.io/jij-inc/jij-mcp-server:latest


### PR DESCRIPTION
- `uv`-based MCP server has two disadvantage
  - Need for `git clone`
  - Runs on the local environment without sandboxing
- `docker`-based MCP server resolves them
  - Much simple install
  - Run in sandboxed environment
- This PR keeps `uv`-based one as it is since it will be useful for development.

Tasks
------
- [x] Dockerfile for MCP server
  - [x] `docker-compose.yml` as a build setting file
  - [x] Push to GitHub Container registry https://github.com/orgs/Jij-Inc/packages/container/package/jij-mcp-server
  - [x] Build and Push docker image on GitHub Actions
    - This workflow is disabled until this PR is merged since this requires permission changes.
- [x] Add [Docker version section in README.md](https://github.com/Jij-Inc/Jij-MCP-Server/tree/docker?tab=readme-ov-file#docker-version)
  - [x] Add vscode auto-install link