### PR TITLE
Enable docker workflow for tag push and PR, use `latest` for main branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-  # Please re-enable this when the PR #2 has been merged
-  # pull_request:
+    tags:
+      - "*"
+  pull_request:
 
 jobs:
   build-and-push:
@@ -29,5 +30,5 @@ jobs:
           docker compose build
           docker compose push
         env:
-          GIT_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          GIT_BRANCH: ${{ (github.event_name == 'pull_request' && github.head_ref || github.ref_name) == 'main' && 'latest' || (github.event_name == 'pull_request' && github.head_ref || github.ref_name) }}
           GIT_COMMIT: ${{ github.sha }}


### PR DESCRIPTION
Follow up of #2 

- Enable docker push on git tags and pull requests
- Use `latest` tag for workflow triggered on the `main` branch